### PR TITLE
Add -Werror=format-security CXXFLAGS support

### DIFF
--- a/xarchive.cpp
+++ b/xarchive.cpp
@@ -802,7 +802,7 @@ void XArchive::showRecords(QList<XArchive::RECORD> *pListArchive)
 
     for(int i=0;i<nCount;i++)
     {
-        qDebug(pListArchive->at(i).sFileName.toLatin1().data());
+        qDebug("%s", pListArchive->at(i).sFileName.toLatin1().data());
     }
 }
 


### PR DESCRIPTION
The commit fixes the following error:
```bash
../XArchive/xarchive.cpp:805:15: error: format not a string literal and no format arguments [-Werror=format-security]
  805 |         qDebug(pListArchive->at(i).sFileName.toLatin1().data());
```

# Informations

On Arch Linux, in the file `/etc/makepkg.conf` of the `core/pacman` package[1], the default value of `CFLAG` and `CXXFLAGS` are set with the following code and are causing a build error upon compiling XArchive.

It should be a good practice to support `-Werror=format-security` rather than disabling it with `-Wno-format-security`

```CMake
CFLAGS="-march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions \
        -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security \
        -fstack-clash-protection -fcf-protection"
CXXFLAGS="$CFLAGS -Wp,-D_GLIBCXX_ASSERTIONS"
```

[1] https://archlinux.org/packages/core/x86_64/pacman/
[1] https://archlinux.org/packages/core/x86_64/pacman/download/